### PR TITLE
Topic/lukev/improvements

### DIFF
--- a/bibifi-periodic/periodic.py
+++ b/bibifi-periodic/periodic.py
@@ -158,7 +158,7 @@ class TeamData:
     if self.canTestRepo():
       b = "%s/%s" % (ARCHIVE_BASE, self.teamName)
       try:
-        os.mkdir(b)
+        os.makedirs(b)
       except:
         pass
       p = "%s/%s.tar.gz" % (b, s)
@@ -175,7 +175,7 @@ class TeamData:
     if self.canTestRepo():
       b = "%s/%s" % (ARCHIVE_BASE, self.teamName)
       try:
-        os.mkdir(b)
+        os.makedirs(b)
       except:
         pass
       p = "%s/%s.tar.gz" % (b, s)
@@ -367,7 +367,7 @@ def test_team_break(teamdata,testedset):
           # Zip up test.
           zipdir = "%s%s" % (BREAKS_BASE, teamdata.teamName)
           try:
-            os.mkdir( zipdir)
+            os.makedirs( zipdir)
           except:
             pass
           zippath = "%s/%s" % (zipdir, testname)
@@ -461,12 +461,12 @@ def test_team_fix(teamdata, testedset):
         commithash,breakids = n
         #do an archive at the point of the fix
         if not os.path.isdir(ARCHIVE_BASE+"/"+teamdata.teamName):
-          os.mkdir(ARCHIVE_BASE+"/"+teamdata.teamName)
+          os.makedirs(ARCHIVE_BASE+"/"+teamdata.teamName)
         pth = "%s/%s/%s.tar.gz" % (ARCHIVE_BASE,teamdata.teamName,commithash)
         f = file(pth, 'w')
         try:
           teamdata.repo.archive(f, treeish=commithash)
-        except git.GitCommandError:
+        except (git.GitCommandError, TypeError):
           print "someone gave us a nonexistant treeish"
           return False
         f.close()

--- a/bibifi-runner/README.md
+++ b/bibifi-runner/README.md
@@ -10,4 +10,4 @@ A team can only run one test at a time.
 `runner` will also run the scorer when necessary. 
 The contest url is the unique url identifier for the contest. 
 Database settings are loaded from `/fs/mc2-application/config/postgresql.yml`. 
-AWS settings are laoded from `/fs/mc2-application/config/aws.yml`.
+Cloud settings are loaded from `/fs/mc2-application/config/cloud.yml`.

--- a/bibifi-runner/src/Cloud.hs
+++ b/bibifi-runner/src/Cloud.hs
@@ -33,7 +33,7 @@ productionCloudYML = "/fs/mc2-application/config/cloud.yml"
 
 loadCloudConfiguration :: String -> IO CloudConfiguration
 loadCloudConfiguration configFile = do
-    -- Read 'config/aws.yml'
+    -- Read 'config/cloud.yml'
     yamlE <- decodeFileEither configFile
     case yamlE of
         Left err -> 


### PR DESCRIPTION
- Auto-create directories (BASE_PATH, ARCHIVE_PATH, BREAKS_PATH, etc.) in bibifi-periodic/periodic.py when they do not already exist. These directories should either be created automatically when they don't exist, or the periodic.py script should exit with a message that the directories don't exist.
- Catch TypeError bug. This came up when a student messed with their git history causing the periodic.py script to look for a non-existent treeish, which caused it to crash.
- Fix some comments: aws -> cloud